### PR TITLE
Upgrade from actions/checkout@v2 to v3

### DIFF
--- a/.github/workflows/do_prediction.yml
+++ b/.github/workflows/do_prediction.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
-  schedule:
-  - cron: "0 20 * * *"
+  #schedule:
+  #- cron: "0 20 * * *"
 
 jobs:
   build:
@@ -13,7 +13,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
+      - name: install R packages
+        run: R -e 'source("install.R")' 
 # Point to the right path, run the right Rscript command
       - name: Run automatic prediction file
         run: /usr/local/bin/r forecast_model.R || true

--- a/.github/workflows/do_prediction.yml
+++ b/.github/workflows/do_prediction.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
-  #schedule:
-  #- cron: "0 20 * * *"
+  schedule:
+  - cron: "0 20 * * *"
 
 jobs:
   build:
@@ -10,11 +10,10 @@ jobs:
       image: eco4cast/rocker-neon4cast
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: install R packages
-        run: R -e 'source("install.R")' 
+          
 # Point to the right path, run the right Rscript command
       - name: Run automatic prediction file
         run: /usr/local/bin/r forecast_model.R || true


### PR DESCRIPTION
js 12 and thus actions/checkout@v2 being deprecated https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

gets rid of this warning 

![image](https://user-images.githubusercontent.com/464871/198745215-a629c6fe-ee3c-40e8-b20b-2b08a87398d8.png)
