### PR TITLE
Be more RAM efficient

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,5 +5,5 @@ FROM ghcr.io/rocker-org/devcontainer/geospatial:4.2
 # RUN R -e 'if(file.exists("install.R")) source("install.R")'
 
 RUN R -e "remotes::install_github('eco4cast/neon4cast')"
-RUN R -e "install.packages(rMR)"
+RUN R -e "install.packages('rMR')"
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # devcontainer-focused Rocker
 FROM ghcr.io/rocker-org/devcontainer/geospatial:4.2
 
-RUN R -e 'if(file.exists("DESCRIPTION")) remotes::install_deps()'
-RUN R -e 'if(file.exists("install.R")) source("install.R")'
+RUN R -e 'if(file.exists("../DESCRIPTION")) remotes::install_deps(..)'
+RUN R -e 'if(file.exists("../install.R")) source("../install.R")'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # devcontainer-focused Rocker
 FROM ghcr.io/rocker-org/devcontainer/geospatial:4.2
 
-RUN R -e 'remotes::install_github("eco4cast/neon4cast")'
-
+RUN R -e 'if(file.exists("DESCRIPTION")) remotes::install_deps()'
+RUN R -e 'source("install.R")'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,4 @@
 FROM ghcr.io/rocker-org/devcontainer/geospatial:4.2
 
 RUN R -e 'if(file.exists("DESCRIPTION")) remotes::install_deps()'
-RUN R -e 'source("install.R")'
+RUN R -e 'if(file.exists("install.R")) source("install.R")'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,9 @@
 # devcontainer-focused Rocker
 FROM ghcr.io/rocker-org/devcontainer/geospatial:4.2
 
-RUN R -e 'if(file.exists("../DESCRIPTION")) remotes::install_deps(..)'
-RUN R -e 'if(file.exists("../install.R")) source("../install.R")'
+# must be in .devcontainer dir
+# RUN R -e 'if(file.exists("install.R")) source("install.R")'
+
+RUN R -e "remotes::install_github('eco4cast/neon4cast')"
+RUN R -e "install.packages(rMR)"
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
   },
 	  
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "sudo rstudio-server start",
+  "postCreateCommand": "sudo rstudio-server start",
+  "postAttachCommand": "sudo rstudio-server start",
   "remoteUser": "rstudio"
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,4 @@
+Package: package
+Version: 0.1.0
+Depends: neon4cast, rME
+Remotes: github::eco4cast/neon4cast

--- a/forecast_model.R
+++ b/forecast_model.R
@@ -72,7 +72,6 @@ forecast_site <- function(site) {
   site_info <- site_data |> dplyr::filter(field_site_id == site)
   
   noaa_past_mean <- noaa_mean_historical(df_past, site, "air_temperature")
-  noaa_future <- noaa_mean_forecast(df_future, site, "air_temperature")
 
   #Merge in past NOAA data into the targets file, matching by date.
   site_target <- target |>
@@ -82,9 +81,15 @@ forecast_site <- function(site) {
     tidyr::pivot_wider(names_from = "variable", values_from = "observation") |>
     dplyr::left_join(noaa_past_mean, by = c("datetime"))
 
-  rm(noaa_past_mean)
-  # Fit linear model based on past data: water temperature = m * air temperature + b
+  rm(noaa_past_mean) # save RAM 
+  
+  # Fit linear model based o # n past data: water temperature = m * air temperature + b
   fit <- lm(temperature ~ air_temperature, data = site_target)
+  
+  rm(site_target) # save RAM
+
+  noaa_future <- noaa_mean_forecast(df_future, site, "air_temperature")
+
 
   # use linear regression to forecast water temperature for each ensemble member
   forecasted_temperature <- fit$coefficients[1] + 

--- a/forecast_model.R
+++ b/forecast_model.R
@@ -148,4 +148,4 @@ write_csv(forecast, forecast_file)
 
 # Step 4: Submit forecast!
 
-# neon4cast::submit(forecast_file = forecast_file, metadata = NULL, ask = FALSE)
+neon4cast::submit(forecast_file = forecast_file, metadata = NULL, ask = FALSE)

--- a/forecast_model.R
+++ b/forecast_model.R
@@ -124,7 +124,6 @@ forecast_site <- function(site) {
 
 forecast <- map_dfr(sites, forecast_site)
 
-
 forecast <- forecast |>
   mutate(reference_datetime = forecast_date,
          family = "ensemble",
@@ -134,10 +133,10 @@ forecast <- forecast |>
          site_id, family, parameter, variable, prediction)
 
 #Visualize forecast.  Is it reasonable?
-#forecast |>
-#  ggplot(aes(x = time, y = prediction, group = ensemble)) +
-#  geom_line() +
-#  facet_grid(variable~site_id, scale ="free")
+forecast |> filter(site_id %in% sites[1:6]) |> # not too many sites
+  ggplot(aes(x = datetime, y = prediction, group = parameter)) +
+  geom_line(alpha=0.3) +
+  facet_grid(variable~site_id, scale ="free")
 
 #Forecast output file name in standards requires for Challenge.
 # csv.gz means that it will be compressed

--- a/forecast_model.R
+++ b/forecast_model.R
@@ -4,6 +4,7 @@ library(neon4cast)
 library(lubridate)
 library(rMR)
 library(glue)
+source("ignore_sigpipe.R")
 
 forecast_date <- Sys.Date()
 noaa_date <- Sys.Date() - days(3)  #Need to use yesterday's NOAA forecast because today's is not available yet

--- a/forecast_model.R
+++ b/forecast_model.R
@@ -3,25 +3,26 @@ library(tidyverse)
 library(neon4cast)
 library(lubridate)
 library(rMR)
+library(glue)
 
 forecast_date <- Sys.Date()
-noaa_date <- Sys.Date() - days(1)  #Need to use yesterday's NOAA forecast because today's is not available yet
+noaa_date <- Sys.Date() - days(3)  #Need to use yesterday's NOAA forecast because today's is not available yet
 
-#Step 0: Define team name and team members 
-
+# Step 0: Define a unique name which will identify your model in the leaderboard and connect it to team members info, etc
 model_id <- "neon4cast_example"
 
-#Step 1: Download latest target data and site description data
-
-target <- readr::read_csv("https://data.ecoforecast.org/neon4cast-targets/aquatics/aquatics-targets.csv.gz", guess_max = 1e6)
-
-site_data <- readr::read_csv("https://raw.githubusercontent.com/eco4cast/neon4cast-targets/main/NEON_Field_Site_Metadata_20220412.csv") |> 
+# Step 1: Download latest target data and site description data
+target <- readr::read_csv(paste0("https://data.ecoforecast.org/neon4cast-targets/",
+                                 "aquatics/aquatics-targets.csv.gz"), guess_max = 1e6)
+site_data <- readr::read_csv(paste0("https://raw.githubusercontent.com/eco4cast/neon4cast-targets/",
+                                    "main/NEON_Field_Site_Metadata_20220412.csv")) |> 
   dplyr::filter(aquatics == 1)
 
 
-#Step 2: Get drivers
+# Step 2: Get meterological predictions as drivers
 df_past <- neon4cast::noaa_stage3()
 
+## Helper function: for each site, average over predicted 0h horizon ensembles to get 'historic values'
 noaa_mean_historical <- function(df_past, site, var) {
   df_past |>
     dplyr::filter(site_id == site,
@@ -37,26 +38,25 @@ noaa_mean_historical <- function(df_past, site, var) {
     dplyr::collect()
 }
 
-noaa_mean_forecast <- function(site, var) {
-  ## Use way less RAM
+## Helper fn: get daily average temperature from each ensemble in future
+noaa_mean_forecast <- function(site, var, reference_date) {
   endpoint = "data.ecoforecast.org"
-  bucket <- glue::glue("neon4cast-drivers/noaa/gefs-v12/stage2/parquet/0/{noaa_date}")
+  bucket <- glue::glue("neon4cast-drivers/noaa/gefs-v12/stage1/0/{reference_date}")
   s3 <- arrow::s3_bucket(bucket, endpoint_override = endpoint, anonymous = TRUE)
   
-  lazy <- arrow::open_dataset(s3) |>
-  dplyr::filter(site_id == site,
-                datetime >= lubridate::as_datetime(forecast_date),
-                variable == var) |>
-  dplyr::select(datetime, prediction, parameter) |>
-  dplyr::mutate(datetime = as_date(datetime)) |>
-  dplyr::group_by(datetime, parameter) |>
-  dplyr::summarize(air_temperature = mean(prediction), .groups = "drop") |>
-  dplyr::mutate(air_temperature = air_temperature - 273.15) |>
-  dplyr::select(datetime, air_temperature, parameter) |>
-  dplyr::rename(ensemble = parameter) |>
-  dplyr::compute()
-  gc()
-  lazy |> dplyr::collect()
+  arrow::open_dataset(s3) |>
+    dplyr::filter(site_id == site,
+                  datetime >= lubridate::as_datetime(forecast_date),
+                  variable == var) |>
+    dplyr::select(datetime, prediction, parameter) |>
+    dplyr::mutate(datetime = as_date(datetime)) |>
+    dplyr::group_by(datetime, parameter) |>
+    dplyr::summarize(air_temperature = mean(prediction), .groups = "drop") |>
+    dplyr::mutate(air_temperature = air_temperature - 273.15) |>
+    dplyr::select(datetime, air_temperature, parameter) |>
+    dplyr::rename(ensemble = parameter) |>
+    dplyr::collect()
+  
 }
 
 # Step 2.5: We'll skip any site that doesn't have both temperature and oxygen
@@ -64,67 +64,71 @@ sites <- target |> na.omit() |> distinct(site_id, variable) |>
   filter(variable %in% c("oxygen", "temperature")) |>
   count(site_id) |> filter(n==2) |> pull(site_id)
 
-site <- sites[[1]]
 
-#Step 3.0: Generate forecasts for each site
-
+#Step 3.0: Define the forecasts model for a site
 forecast_site <- function(site) {
   message(paste0("Running site: ", site))
-
+  
   # Get site information for elevation
   site_info <- site_data |> dplyr::filter(field_site_id == site)
   
+  # historical temperatures
   noaa_past_mean <- noaa_mean_historical(df_past, site, "air_temperature")
-
-  #Merge in past NOAA data into the targets file, matching by date.
+  
+  # Merge in past NOAA data into the targets file, matching by date.
   site_target <- target |>
     dplyr::select(datetime, site_id, variable, observation) |>
     dplyr::filter(variable %in% c("temperature", "oxygen"), 
                   site_id == site) |>
     tidyr::pivot_wider(names_from = "variable", values_from = "observation") |>
     dplyr::left_join(noaa_past_mean, by = c("datetime"))
-
+  
   rm(noaa_past_mean) # save RAM 
   
   # Fit linear model based o # n past data: water temperature = m * air temperature + b
   fit <- lm(temperature ~ air_temperature, data = site_target)
   
-  rm(site_target) # save RAM
-
-  noaa_future <- noaa_mean_forecast(site, "air_temperature")
-
-  # use linear regression to forecast water temperature for each ensemble member
-  #forecasted_temperature <- fit$coefficients[1] + fit$coefficients[2] * noaa_future$air_temperature
-
+  #  Get 30-day predicted temperature ensemble at the site
+  noaa_future <- noaa_mean_forecast(site, "TMP", noaa_date)
+  
+  # use the linear model (predict.lm) to forecast water temperature for each ensemble member
   temperature <- 
     noaa_future |> 
     mutate(site_id = site,
            prediction = predict(fit, tibble(air_temperature)),
            variable = "temperature")
-
-  # use forecasted temperature to predict oyxgen by assuming that oxygen is saturated.
+  
+  # use forecasted water temperature to predict oxygen by assuming that oxygen is saturated.
   forecasted_oxygen <- 
-    rMR::Eq.Ox.conc(temperature$air_temperature, 
+    rMR::Eq.Ox.conc(temperature$prediction, 
                     elevation.m = site_info$field_mean_elevation_m,
                     bar.press = NULL,
                     bar.units = NULL,
                     out.DO.meas = "mg/L",
                     salinity = 0,
                     salinity.units = "pp.thou")
-
+  # stick bits together                  
   oxygen <- 
     noaa_future |> 
     mutate(site_id = site,
            prediction = forecasted_oxygen,
            variable = "oxygen")
-
-  # Build site level dataframe.  Note we are not forecasting chla
-  dplyr::bind_rows(temperature, oxygen)
-
+  
+  out <- dplyr::bind_rows(temperature, oxygen)
+  
+  out
 }
 
+
+### HERE WE GO! ### 
+# Actually compute the forecast at each site. 
 forecast <- map_dfr(sites, forecast_site)
 
+
+
+
+
+# Format results to EFI standard
 forecast <- forecast |>
   mutate(reference_datetime = forecast_date,
          family = "ensemble",
@@ -133,7 +137,7 @@ forecast <- forecast |>
   select(model_id, datetime, reference_datetime,
          site_id, family, parameter, variable, prediction)
 
-#Visualize forecast.  Is it reasonable?
+#Visualize some forecasts.  Are they reasonable?
 forecast |> filter(site_id %in% sites[1:6]) |> # not too many sites
   ggplot(aes(x = datetime, y = prediction, group = parameter)) +
   geom_line(alpha=0.3) +
@@ -146,7 +150,7 @@ forecast_file <- paste0("aquatics","-",file_date,"-",model_id,".csv.gz")
 
 #Write csv to disk
 write_csv(forecast, forecast_file)
-q
+
 # Step 4: Submit forecast!
 
 neon4cast::submit(forecast_file = forecast_file, metadata = NULL, ask = FALSE)

--- a/forecast_model.R
+++ b/forecast_model.R
@@ -91,7 +91,8 @@ forecast <- NULL
         fit$coefficients[2] * noaa_future_site$air_temperature
 
       #use forecasted temperature to predict oyxgen by assuming that oxygen is saturated.
-      forecasted_oxygen <- rMR::Eq.Ox.conc(forecasted_temperature, elevation.m = site_info$field_mean_elevation_m,
+      forecasted_oxygen <- rMR::Eq.Ox.conc(forecasted_temperature, 
+                                           elevation.m = site_info$field_mean_elevation_m,
                                            bar.press = NULL,
                                            bar.units = NULL,
                                            out.DO.meas = "mg/L",

--- a/ignore_sigpipe.R
+++ b/ignore_sigpipe.R
@@ -1,0 +1,10 @@
+library(decor)
+cpp11::cpp_source(code = '
+#include <csignal>
+#include <cpp11.hpp>
+
+[[cpp11::register]] void ignore_sigpipes() {
+  signal(SIGPIPE, SIG_IGN);
+}
+')
+ignore_sigpipes()

--- a/install.R
+++ b/install.R
@@ -1,1 +1,3 @@
 install.packages("rMR")
+install.packages("decor")
+

--- a/neon4cast-example.Rproj
+++ b/neon4cast-example.Rproj
@@ -11,3 +11,7 @@ Encoding: UTF-8
 
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
I refactored things a bit, I think this should keep the run near 1 GB RAM, instead of 6-8GB.  

I also took the liberty of functionalizing the code a bit.  I'm not sure if it helps readability that much, but maybe a little.

Minor tweak to avoid the `if` statement too, if we just determine up front which sites are missing one of the variables then we can avoid even having to grab the NOAA data for them.  


Bigger-picture-wise, we may want to think of more derived products... e.g. it feels weird to interpolate Stage2 down to the hour interval only to aggregate it back up to the day interval, if everyone wants daily average stage 2 we should probably provide it.  (Lesson from Lester as well has been that providing nicely pre-processed driver data that is _ready to go_ is one of the best things you can do to get more people forecasting!)